### PR TITLE
prometheus: Update default tsdb path

### DIFF
--- a/utils/prometheus/files/etc/init.d/prometheus
+++ b/utils/prometheus/files/etc/init.d/prometheus
@@ -12,7 +12,7 @@ start_service() {
 	local web_listen_address
 	config_load "prometheus"
 	config_get config_file prometheus config_file "$CONFFILE"
-	config_get storage_tsdb_path prometheus storage_tsdb_path "/data"
+	config_get storage_tsdb_path prometheus storage_tsdb_path "/var/prometheus-data"
 	config_get web_listen_address prometheus web_listen_address "127.0.0.1:9090"
 
 	procd_open_instance

--- a/utils/prometheus/files/etc/uci-defaults/prometheus-defaults
+++ b/utils/prometheus/files/etc/uci-defaults/prometheus-defaults
@@ -6,7 +6,7 @@ uci -q get prometheus.prometheus || {
 	uci -q batch <<EOF
 	set prometheus.prometheus=prometheus
 	set prometheus.prometheus.config_file='/etc/prometheus.yml'
-	set prometheus.prometheus.storage_tsdb_path='/data'
+	set prometheus.prometheus.storage_tsdb_path='/var/prometheus-data'
 	set prometheus.prometheus.web_listen_address='127.0.0.1:9090'
 	commit prometheus
 EOF


### PR DESCRIPTION
Maintainer: @aparcar 
Compile tested: -
Run tested: linux/arm64, RaspberryPI4 model B, snapshot - by editing `/etc/config/prometheus` manually


Description: Use /var/prometheus-data instead of /data, because user `prometheus` doesn't have permissions to create directory in root filesystem, while it's totally fine to be in /var